### PR TITLE
Fix Xcode Build issues by removing merge conflict leftovers from code

### DIFF
--- a/ALUM/ALUM.xcodeproj/project.pbxproj
+++ b/ALUM/ALUM.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		2A8E07E1297B4FB0001AA153 /* OutlinedButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlinedButtonStyle.swift; sourceTree = "<group>"; };
 		804AE4AC297B1DA4000B08F2 /* FilledInButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilledInButtonStyle.swift; sourceTree = "<group>"; };
 		9752A4E92978B90F001E0AAB /* TextInputFieldComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputFieldComponent.swift; sourceTree = "<group>"; };
-    main
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,7 +83,6 @@
 				804AE4AC297B1DA4000B08F2 /* FilledInButtonStyle.swift */,
 				2A8E07E1297B4FB0001AA153 /* OutlinedButtonStyle.swift */,
 				9752A4E92978B90F001E0AAB /* TextInputFieldComponent.swift */,
-        main
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -191,7 +189,6 @@
 				804AE4AD297B1DA4000B08F2 /* FilledInButtonStyle.swift in Sources */,
 				2A8E07E2297B4FB0001AA153 /* OutlinedButtonStyle.swift in Sources */,
 				9752A4EA2978B90F001E0AAB /* TextInputFieldComponent.swift in Sources */,
-        main
 				0748209129712921004AF547 /* ContentView.swift in Sources */,
 				0748208F29712921004AF547 /* ALUMApp.swift in Sources */,
 			);


### PR DESCRIPTION
### Tracking Info

Make sure your branch name conforms to: `<feature|staging|bugfix|...>/<username>/<3-4 word description separated by dashes>`. Otherwise, please rename your branch and create a new PR.

Looks like when merge conflict was resolved in commit [d4bfb5c](https://github.com/TritonSE/ALUM-Mobile-Application/commit/d4bfb5c42a0dd7b4a8757094a35fea8c69757492) some lines like `main` got left in the codebase. This was causing a parse error when opening the project through xcode. 

Future note - 
Running `xcodeproj show ALUM.xcodeproj` from terminal gives more details on what kind of error happened because of which XCode is not opening

### Changes

What changes did you make?

- Removed some leftovers from a previous merge conflict resolution

### Testing

How did you confirm your changes worked? 

- Ran previews for the existing components on Xcode

### Confirmation of Change 

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/56745367/214180132-18a64a72-ab01-4aa6-84e6-c60d6367976b.png">
