### PR TITLE
sessions GET returns an array of sessionIDs not a bunch of session info

### DIFF
--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -3,7 +3,7 @@
  */
 
 import express, { NextFunction, Request, Response } from "express";
-import mongoose from "mongoose";
+import mongoose, { ObjectId } from "mongoose";
 import { Session } from "../models/session";
 import { createPreSessionNotes, createPostSessionNotes } from "../services/note";
 import { verifyAuthToken } from "../middleware/auth";
@@ -118,14 +118,18 @@ router.get(
       if (role === "mentor") {
         userSessions = await Session.find({ mentorId: { $eq: userID } });
       }
-      if (userSessions === null) {
-        return res.status(400).json({
-          message: `No sessions found for user ${userID}!`,
+      if (userSessions != null) {
+        const sessionsArray: ObjectId[] = [];
+        userSessions.forEach((session) => {
+          sessionsArray.push(session._id);
+        });
+        return res.status(200).json({
+          message: `Sessions for user ${userID}:`,
+          sessions: sessionsArray,
         });
       }
-      return res.status(200).json({
-        message: `Sessions for user ${userID}:`,
-        sessions: userSessions,
+      return res.status(400).json({
+        message: `No sessions found for user ${userID}!`,
       });
     } catch (e) {
       next();


### PR DESCRIPTION

### Changes

Sessions GET route now returns an array of all sessionIDs instead of an array of sessions with all their info.

### Testing

<img width="996" alt="image" src="https://user-images.githubusercontent.com/99223047/234747213-e307847b-c66d-4e08-9063-fc2daa56c063.png">

