### PR TITLE
add a workflow to create a pr from main to deployment

### DIFF
--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -1,0 +1,20 @@
+name: Deploy `main` to `deployment`
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: main
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3.7.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: deployment
+        title: "Merge from main to deployment"
+        body: "Automatically generated pull request"


### PR DESCRIPTION
### Tracking Info

Add a workflow that can deploy from main to deployment. Since we now have access to xcode cloud, it will be useful to have a deployment branch for pushing app to xcode cloud for previews occasionally.

Resolves #<issue number>

Make sure your branch name conforms to: `<feature|staging|bugfix|...>/<username>/<3-4 word description separated by dashes>`. Otherwise, please rename your branch and create a new PR.

### Changes

What changes did you make?
- Add a github workflow

### Testing

How did you confirm your changes worked? 
- Not tested yet cauz can't test until merged in main

### Confirmation of Change 
N/A
